### PR TITLE
Misc fixes and results on mobile

### DIFF
--- a/indexes.js
+++ b/indexes.js
@@ -123,6 +123,6 @@ module.exports = function (opts, cb) {
 
 }
 
-if(!module.partent)
+if(!module.parent)
   module.exports(minimist(process.argv.slice(2)))
 

--- a/init.js
+++ b/init.js
@@ -7,66 +7,70 @@ var mkdirp = require('mkdirp')
 var bipf = require('bipf')
 var path = require('path')
 var pull = require('pull-stream')
-
 var minimist = require('minimist')
-var opts = minimist(process.argv.slice(2))
 
-var source = opts.offset || path.join(process.env.HOME, '.ssb/flume/log.offset')
-var dest = opts.aligned || '/tmp/test-raf/log.aligned'
-try { fs.stat(source) } catch(err) {
-  console.error('source log.offset file does not exist')
-  throw err
-}
-
-//rmr.syncf(path.dirname(dest))
-mkdirp.sync(path.dirname(dest))
-try { fs.unlinkSync(dest) } catch(_) {} //delete the file if it's already there
-
-var block = 1024*64 //64k blocks
-var MB = 1024*1024
-var log = FlumeLogOffset(source, {blockSize: block, codec: codec.json})
-var log2 = FlumeLogAligned (dest, {block: block})
-
-console.log('records, mb, seconds')
-function log_progress () {
-  console.log([c, length/MB, (Date.now() - start)/1000].join(', '))
-}
-
-function progress() {
-  if(Date.now() > ts + 1000) {
-    log_progress()
-    ts = Date.now()
+module.exports = function (opts, cb) {
+  var source = opts.offset || path.join(process.env.HOME, '.ssb/flume/log.offset')
+  var dest = opts.aligned || '/tmp/test-raf/log.aligned'
+  try { fs.stat(source) } catch(err) {
+    console.error('source log.offset file does not exist')
+    throw err
   }
-}
 
-var start = Date.now(), c = 0, length = 0, ts = Date.now()
-pull(
-  log.stream({seqs:false}),
-  pull.map(function (data) {
-    var len = bipf.encodingLength(data)
-    var b = Buffer.alloc(len)
-    length += b.length + 4
-    bipf.encode(data, b, 0)
-    return b
-  }),
-  function (read) {
-    read(null, function next (err, data) {
-      c ++
-      progress()
-      if(err) return done(err === true ? null : err)
-      log2.append(data, function () {})
-      if(log2.appendState.offset > log2.appendState.written + block*10)
-        log2.onDrain(function () {
+  //rmr.syncf(path.dirname(dest))
+  mkdirp.sync(path.dirname(dest))
+  try { fs.unlinkSync(dest) } catch(_) {} //delete the file if it's already there
+
+  var block = 1024*64 //64k blocks
+  var MB = 1024*1024
+  var log = FlumeLogOffset(source, {blockSize: block, codec: codec.json})
+  var log2 = FlumeLogAligned (dest, {block: block})
+
+  console.log('records, mb, seconds')
+  function log_progress () {
+    console.log([c, length/MB, (Date.now() - start)/1000].join(', '))
+  }
+
+  function progress() {
+    if(Date.now() > ts + 1000) {
+      log_progress()
+      ts = Date.now()
+    }
+  }
+
+  var start = Date.now(), c = 0, length = 0, ts = Date.now()
+  pull(
+    log.stream({seqs:false}),
+    pull.map(function (data) {
+      var len = bipf.encodingLength(data)
+      var b = Buffer.alloc(len)
+      length += b.length + 4
+      bipf.encode(data, b, 0)
+      return b
+    }),
+    function (read) {
+      read(null, function next (err, data) {
+        c ++
+        progress()
+        if(err) return done(err === true ? null : err)
+        log2.append(data, function () {})
+        if(log2.appendState.offset > log2.appendState.written + block*10)
+          log2.onDrain(function () {
+            read(null, next)
+          })
+        else
           read(null, next)
-        })
-      else
-        read(null, next)
-    })
-  }
-)
+      })
+    }
+  )
 
-function done (err) {
-  if(err) throw err
-  log_progress()
+  function done (err) {
+    if(err) throw err
+    log_progress()
+    cb && cb(null, true)
+  }
 }
+
+if(!module.parent)
+  module.exports(minimist(process.argv.slice(2)))
 


### PR DESCRIPTION
Hey Dominic, I started testing this out on mobile. There were two changes I had to do in this package to get things working. There is one change per commit.

--- 

Since I have your attention, I'll just publish here (besides elsewhere) the results of my experiment.

- Manyverse running on Android with an *empty* account, with this module installed
- sbot running on my laptop, with a dummy account
- laptop dummy account posted 100x `"content": {"type":"post","text":"hello"}` posts
- Manyverse account synced with the laptop account through wifi
- I manually activated this module's `init()` on Manyverse, see results below
- I waited a bit, then manually activated this module's `indexes()` on Manyverse, see results below
- I waited a bit, then manually activated this module's `query()` on Manyverse, see results below

### init

```
records, mb, seconds
101, 0.03850746154785156, 0.167
```

### indexes

```
seconds, key, log, cts, clk, tyt, tya, rtt, cta, aty, att
reindex, key, 39975, -1
ended, key, 100, 39974
reindex, log, 39975, -1
reindex, cts, 39975, -1
reindex, clk, 39975, -1
reindex, tyt, 39975, -1
reindex, tya, 39975, -1
reindex, rtt, 39975, -1
reindex, cta, 39975, -1
reindex, aty, 39975, -1
reindex, att, 39975, -1
indexes/log:compacting [ 100 ]
sort time: 14 14 14 100
indexes/cts:compacting [ 100 ]
indexes/clk:compacting [ 100 ]
indexes/tyt:compacting [ 100 ]
indexes/tya:compacting [ 100 ]
indexes/aty:compacting [ 100 ]
indexes/att:compacting [ 100 ]
sort time: 15 29 15 100
sort time: 26 55 26 100
sort time: 36 91 36 100
sort time: 22 113 36 100
indexes/rtt:compacted! NaN undefined
undefined
ended, rtt, 100, 39974
indexes/cta:compacted! NaN undefined
undefined
ended, cta, 100, 39974
sort time: 31 144 36 100
sort time: 32 176 36 100
indexes/log:compacted! 213 100
{ input: [ { size: 100, latest: 39974 } ],
  count: 2,
  total: 101,
  average: 50.5,
  since: 39974,
  meta: { since: 39974, index: [ '1547035671080.idx' ] } }
ended, log, 100, 39974
indexes/cts:compacted! 193 100
{ input: [ { size: 100, latest: 39974 } ],
  count: 2,
  total: 101,
  average: 50.5,
  since: 39974,
  meta: { since: 39974, index: [ '1547035671102.idx' ] } }
ended, cts, 100, 39974
indexes/clk:compacted! 193 100
{ input: [ { size: 100, latest: 39974 } ],
  count: 2,
  total: 101,
  average: 50.5,
  since: 39974,
  meta: { since: 39974, index: [ '1547035671103.idx' ] } }
ended, clk, 100, 39974
indexes/tyt:compacted! 195 100
{ input: [ { size: 100, latest: 39974 } ],
  count: 2,
  total: 101,
  average: 50.5,
  since: 39974,
  meta: { since: 39974, index: [ '1547035671103.idx' ] } }
ended, tyt, 100, 39974
indexes/tya:compacted! 195 100
{ input: [ { size: 100, latest: 39974 } ],
  count: 2,
  total: 101,
  average: 50.5,
  since: 39974,
  meta: { since: 39974, index: [ '1547035671104.idx' ] } }
ended, tya, 100, 39974
indexes/aty:compacted! 196 100
{ input: [ { size: 100, latest: 39974 } ],
  count: 2,
  total: 101,
  average: 50.5,
  since: 39974,
  meta: { since: 39974, index: [ '1547035671105.idx' ] } }
ended, aty, 100, 39974
indexes/att:compacted! 196 100
{ input: [ { size: 100, latest: 39974 } ],
  count: 2,
  total: 101,
  average: 50.5,
  since: 39974,
  meta: { since: 39974, index: [ '1547035671106.idx' ] } }
ended, att, 100, 39974
0.415, 39974, 39974, 39974, 39974, 39974, 39974, 39974, 39974, 39974, 39974
```

### query

```
seconds, key, log, cts, clk, tyt, tya, rtt, cta, aty, att
reindex, key, 0, 39974
ended, key, 0, 39974
reindex, rtt, 39975, -1
reindex, cta, 39975, -1
reindex, log, 0, 39974
ended, log, 0, 39974
reindex, cts, 0, 39974
ended, cts, 0, 39974
reindex, clk, 0, 39974
ended, clk, 0, 39974
reindex, tyt, 0, 39974
ended, tyt, 0, 39974
reindex, tya, 0, 39974
ended, tya, 0, 39974
reindex, aty, 0, 39974
ended, aty, 0, 39974
reindex, att, 0, 39974
ended, att, 0, 39974
indexes/rtt:compacted! NaN undefined
undefined
ended, rtt, 100, 39974
indexes/cta:compacted! NaN undefined
undefined
ended, cta, 100, 39974
0.054, 39974, 39974, 39974, 39974, 39974, 39974, 39974, 39974, 39974, 39974
flumeview-query: _ in memory log or no indexes defined, will always use full scan, queries will likely be slow
{ since: { [Function: many] set: [Function], once: [Function], value: 39974 },
  get: undefined,
  methods: { get: 'async', read: 'source' },
  read: [Function: read],
  createSink: [Function: createSink] }
normalized-index:sorts 7 176 36
/data/data/se.manyver/files/nodejs-project/index.js:75774
      query.add(Index(indexes[k]))
            ^

TypeError: query.add is not a function
    at /data/data/se.manyver/files/nodejs-project/index.js:75774:13
    at next (/data/data/se.manyver/files/nodejs-project/index.js:81668:11)
    at /data/data/se.manyver/files/nodejs-project/index.js:81610:38
    at again (/data/data/se.manyver/files/nodejs-project/index.js:51544:26)
    at /data/data/se.manyver/files/nodejs-project/index.js:78830:9
    at /data/data/se.manyver/files/nodejs-project/index.js:51218:7
    at /data/data/se.manyver/files/nodejs-project/index.js:83541:5
    at /data/data/se.manyver/files/nodejs-project/index.js:42463:9
    at /data/data/se.manyver/files/nodejs-project/index.js:83546:5
    at /data/data/se.manyver/files/nodejs-project/index.js:78827:14
```